### PR TITLE
[Data Usage] Excludes CA setting from TLS configuration for AutoOps API request

### DIFF
--- a/x-pack/plugins/data_usage/server/services/autoops_api.ts
+++ b/x-pack/plugins/data_usage/server/services/autoops_api.ts
@@ -63,7 +63,6 @@ export class AutoOpsAPIService {
         rejectUnauthorized: tlsConfig.rejectUnauthorized,
         cert: tlsConfig.certificate,
         key: tlsConfig.key,
-        ca: tlsConfig.certificateAuthorities,
       }),
     };
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/constants.ts
@@ -39,6 +39,6 @@ export const getRunFromDockerSnippet = ({ version }: { version: string }) => `do
 -v "$HOME/elastic-connectors:/config" \\
 --tty \\
 --rm \\
-docker.elastic.co/enterprise-search/elastic-connectors:${version} \\
+docker.elastic.co/integrations/elastic-connectors:${version} \\
 /app/bin/elastic-ingest \\
 -c /config/config.yml`;


### PR DESCRIPTION
This PR is a result of the discussion we had about certificates check performed between Kibana and AutoOps API 